### PR TITLE
Compatibility with esphome 2025.2.0

### DIFF
--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -57,7 +57,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.6
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
@@ -72,7 +73,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/gnumpi/esphome_audio
-      ref: dev-next
+      ref: pull/79/head
     components: [ adf_pipeline, i2s_audio ]
     refresh: 0s
 

--- a/firmware/esphome/echo-solo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-solo-b-voice-assist.yaml
@@ -55,7 +55,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.6
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
@@ -70,7 +71,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/gnumpi/esphome_audio
-      ref: dev-next
+      ref: pull/79/head
     components: [ adf_pipeline, i2s_audio ]
     refresh: 0s
 


### PR DESCRIPTION
This contains the changes I needed to apply, to make it build in the recent ESPHome 2025.4.1 version. 

- Updating esp_idf and introducing platform_version
- Referencing a pull request, with a fix for 2025.2.0 in esphome_audio

#5 