### PR TITLE
Use native ESPHome components, instead of the adf_pipeline/esphome_audio

### DIFF
--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -497,13 +497,6 @@ switch:
             - lambda: id(voice_assistant_phase) = ${voice_assist_muted_phase_id};
       - script.execute: reset_led
 
-  - platform: template
-    name: "${friendly_name} Pipeline"
-    id: pipeline_switch
-    optimistic: true
-    restore_mode: RESTORE_DEFAULT_OFF
-    on_turn_off:
-      - media_player.stop
 
   - platform: template
     name: "Enable ducking"

--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -40,7 +40,7 @@ esphome:
     priority: 200.0
     then:
       - media_player.volume_set:
-          id: adf_media_player
+          id: voice_assistant_media_player
           volume: ${speaker_volume}
       - switch.turn_on:
           id: speaker_switch 
@@ -57,25 +57,14 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
       CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM: "512"
       CONFIG_TCPIP_RECVMBOX_SIZE: "512"
-
       CONFIG_TCP_SND_BUF_DEFAULT: "65535"
       CONFIG_TCP_WND_DEFAULT: "512000"
       CONFIG_TCP_RECVMBOX_SIZE: "512"
-
-external_components:
-  - source:
-      type: git
-      url: https://github.com/gnumpi/esphome_audio
-      ref: pull/79/head
-    components: [ adf_pipeline, i2s_audio ]
-    refresh: 0s
 
 # Enable logging
 logger:
@@ -121,20 +110,16 @@ i2s_audio:
   - id: i2s_in
     i2s_lrclk_pin: GPIO7 
     i2s_bclk_pin: GPIO16
+  
   - id: i2s_out
     i2s_lrclk_pin: GPIO8
     i2s_bclk_pin: GPIO18
-    
-adf_pipeline:
-  - platform: i2s_audio
-    type: audio_out
-    id: adf_i2s_out
-    i2s_audio_id: i2s_out
-    i2s_dout_pin: GPIO17
 
+
+microphone:
   - platform: i2s_audio
-    type: audio_in
-    id: adf_i2s_in
+    adc_type: external
+    id: voice_assistant_mic
     i2s_audio_id: i2s_in
     i2s_din_pin: GPIO15
     pdm: false
@@ -142,24 +127,83 @@ adf_pipeline:
     sample_rate: 16000
     bits_per_sample: 32bit
 
-microphone:
-  - platform: adf_pipeline
-    id: adf_microphone
-    keep_pipeline_alive: true
-    pipeline:
-      - adf_i2s_in
-      - self
+# use speaker plattform for mix announcements and media player
+
+speaker:
+  - platform: i2s_audio
+    id: i2s_audio_speaker
+    i2s_audio_id: i2s_out
+    i2s_dout_pin: GPIO17
+    dac_type: external
+    channel: "stereo"
+    i2s_mode: primary
+    buffer_duration: 100ms
+    timeout: never
+    sample_rate: 48000
+    bits_per_sample: 32bit
+
+  - platform: mixer
+    id: mixing_speaker
+    output_speaker: i2s_audio_speaker
+    num_channels: 2
+    source_speakers:
+      - id: announcement_mixing_input
+        timeout: never
+      - id: media_mixing_input
+        timeout: never
+
+  # Virtual speakers to resample each pipelines' audio, if necessary, as the mixer speaker requires the same sample rate
+  - platform: resampler
+    id: announcement_resampling_speaker
+    output_speaker: announcement_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+  - platform: resampler
+    id: media_resampling_speaker
+    output_speaker: media_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+
 
 media_player:
-  - platform: adf_pipeline
-    id: adf_media_player
-    name: "${friendly_name} Media Player"
-    keep_pipeline_alive: true
+  - platform: speaker
+    id: voice_assistant_media_player
+    name: "Media Player"
     internal: false
-    pipeline:
-      - self
-      - resampler
-      - adf_i2s_out
+    announcement_pipeline:
+      speaker: announcement_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 1  # Stereo audio is unnecessary for announcements
+      sample_rate: 48000
+    media_pipeline:
+      speaker: media_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 2
+      sample_rate: 48000
+    on_announcement:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+    on_state:
+      if:
+        condition:
+          and:
+            - switch.is_off: timer_ringing
+            - not:
+                voice_assistant.is_running:
+            - not:
+                media_player.is_announcing:
+        then:
+          - mixer_speaker.apply_ducking:
+              id: media_mixing_input
+              decibel_reduction: 0
+              duration: 1.0s
+    files:
+    - id: timer_finished_sound
+      file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
+    - id: wake_word_triggered_sound
+      file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
 
 light:
   - platform: esp32_rmt_led_strip
@@ -168,7 +212,7 @@ light:
     rgb_order: GRB
     pin: GPIO42
     num_leds: 3
-    rmt_channel: 1
+    rmt_symbols: 96
     chipset: ws2812
     default_transition_length: 0s
     effects:
@@ -201,20 +245,60 @@ light:
 micro_wake_word:
   models:
     - model: ${wake_word}
+  microphone: voice_assistant_mic
   on_wake_word_detected:
-      - media_player.stop:
-      - light.turn_on:
-          id: rgb_front_led
-          blue: 0%
-          red: 0%
-          green: 100%
-          brightness: 75%
-          effect: "Slow Pulse"
-      - voice_assistant.start:
+    - if:
+        condition:
+          switch.is_on: use_wake_word
+        then:
+          - light.turn_on:
+              id: rgb_front_led
+              blue: 0%
+              red: 0%
+              green: 100%
+              brightness: 75%
+              effect: "Slow Pulse"
+          # If a timer is ringing: Stop it, do not start the voice assistant (We can stop timer from voice!)
+          - if:
+              condition:
+                switch.is_on: timer_ringing
+              then:
+                - switch.turn_off: timer_ringing
+                - micro_wake_word.start:
+              # Stop voice assistant if running
+              else:
+                - if:
+                    condition:
+                      voice_assistant.is_running:
+                    then:
+                      voice_assistant.stop:
+                    # Stop any other media player announcement
+                    else:
+                      - if:
+                          condition:
+                            media_player.is_announcing:
+                          then:
+                            - media_player.stop:
+                                announcement: true
+                          # Start the voice assistant and play the wake sound, if enabled
+                          else:
+                            - if:
+                                condition:
+                                  switch.is_on: wake_sound
+                                then:
+                                  - script.execute:
+                                      id: play_sound
+                                      priority: true
+                                      sound_file: !lambda return id(wake_word_triggered_sound);
+                                  - delay: 300ms
+                            
+                            - voice_assistant.start:
+
 
 voice_assistant:
-  microphone: adf_microphone
-  media_player: adf_media_player
+  id: va
+  microphone: voice_assistant_mic
+  media_player: voice_assistant_media_player
   use_wake_word: false
   #vad_threshold: 3
   #noise_suppression_level: 1
@@ -258,14 +342,24 @@ voice_assistant:
         green: 100%
         brightness: 50%
         effect: "Slow Pulse"
+  on_start:
+    - mixer_speaker.apply_ducking:
+        id: media_mixing_input
+        decibel_reduction: 20  # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s         # The duration of the transition (default is no transition)
   on_end:
       then:
+        - wait_until:
+            not:
+              voice_assistant.is_running:
+        # Stop ducking audio.
+        - mixer_speaker.apply_ducking:
+            id: media_mixing_input
+            decibel_reduction: 0
+            duration: 1.0s
         - light.turn_off:
             id: rgb_front_led
         - voice_assistant.stop
-        - wait_until:
-            not:
-              media_player.is_playing:
         - script.execute: reset_led
         - if:
             condition:
@@ -293,6 +387,8 @@ voice_assistant:
         then:
           - micro_wake_word.start:
           - script.execute: reset_led
+  on_timer_finished:
+    - switch.turn_on: timer_ringing
 
 script:
   - id: reset_led
@@ -310,6 +406,53 @@ script:
                 effect: none
           else:
             - light.turn_off: rgb_front_led
+  # Script executed when we want to play sounds on the device.
+  - id: play_sound
+    parameters:
+      priority: bool
+      sound_file: "audio::AudioFile*"
+    then:
+      - lambda: |-
+          if (priority) {
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+              .set_announcement(true)
+              .perform();
+          }
+          if ( (id(voice_assistant_media_player).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
+            id(voice_assistant_media_player)
+              ->play_file(sound_file, true, false);
+          }
+  # Script executed when the timer is ringing, to playback sounds.
+  - id: enable_repeat_one
+    then:
+      # Turn on the repeat mode and pause for 500 ms between playlist items/repeats
+      - lambda: |-
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_ONE)
+              .set_announcement(true)
+              .perform();
+            id(voice_assistant_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 500);
+  - id: ring_timer
+    then:
+      - script.execute: enable_repeat_one
+      - script.execute:
+          id: play_sound
+          priority: true
+          sound_file: !lambda return id(timer_finished_sound);
+  - id: disable_repeat
+    then:
+      # Turn off the repeat mode and pause for 0 ms between playlist items/repeats
+      - lambda: |-
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_OFF)
+              .set_announcement(true)
+              .perform();
+            id(voice_assistant_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 0);
+
 
 switch:
   - platform: gpio
@@ -361,3 +504,54 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     on_turn_off:
       - media_player.stop
+
+  - platform: template
+    name: "Enable ducking"
+    id: ducking_switch
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: mdi:volume-high
+
+  - platform: template
+    id: timer_ringing
+    optimistic: true
+    internal: true
+    restore_mode: ALWAYS_OFF
+    on_turn_on:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+      - script.execute: ring_timer
+      - light.turn_on:
+          id: rgb_front_led
+          blue: 0%
+          red: 0%
+          green: 100%
+          brightness: 85%
+          effect: "Fast Pulse"
+      - delay: 15min
+      - switch.turn_off: timer_ringing
+    on_turn_off:
+      - script.execute: disable_repeat
+      # Stop any current annoucement (ie: stop the timer ring mid playback)
+      - if:
+          condition:
+            media_player.is_announcing:
+          then:
+            media_player.stop:
+              announcement: true
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 0
+          duration: 1.0s
+      - script.execute: reset_led
+    
+
+  - platform: template
+    id: wake_sound
+    name: "${friendly_name} Wake Sound"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: "mdi:bullhorn"
+

--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -272,7 +272,6 @@ micro_wake_word:
                       switch.is_off: ducking_switch
                     then:
                       media_player.stop:
-                        announcement: true
                 - if:
                     condition:
                       voice_assistant.is_running:

--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -57,7 +57,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.6
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
@@ -72,7 +73,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/gnumpi/esphome_audio
-      ref: dev-next
+      ref: pull/79/head
     components: [ adf_pipeline, i2s_audio ]
     refresh: 0s
 

--- a/firmware/esphome/echo-duo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-duo-b-voice-assist.yaml
@@ -269,6 +269,12 @@ micro_wake_word:
               else:
                 - if:
                     condition:
+                      switch.is_off: ducking_switch
+                    then:
+                      media_player.stop:
+                        announcement: true
+                - if:
+                    condition:
                       voice_assistant.is_running:
                     then:
                       voice_assistant.stop:

--- a/firmware/esphome/echo-solo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-solo-b-voice-assist.yaml
@@ -38,7 +38,7 @@ esphome:
     priority: 200.0
     then:
       - media_player.volume_set:
-          id: adf_media_player
+          id: voice_assistant_media_player
           volume: ${speaker_volume}
       - switch.turn_on:
           id: speaker_switch 
@@ -55,25 +55,14 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
       CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM: "512"
       CONFIG_TCPIP_RECVMBOX_SIZE: "512"
-
       CONFIG_TCP_SND_BUF_DEFAULT: "65535"
       CONFIG_TCP_WND_DEFAULT: "512000"
       CONFIG_TCP_RECVMBOX_SIZE: "512"
-
-external_components:
-  - source:
-      type: git
-      url: https://github.com/gnumpi/esphome_audio
-      ref: pull/79/head
-    components: [ adf_pipeline, i2s_audio ]
-    refresh: 0s
 
 # Enable logging
 logger:
@@ -119,20 +108,16 @@ i2s_audio:
   - id: i2s_in
     i2s_lrclk_pin: GPIO7 
     i2s_bclk_pin: GPIO16
+  
   - id: i2s_out
     i2s_lrclk_pin: GPIO8
     i2s_bclk_pin: GPIO18
-    
-adf_pipeline:
-  - platform: i2s_audio
-    type: audio_out
-    id: adf_i2s_out
-    i2s_audio_id: i2s_out
-    i2s_dout_pin: GPIO17
 
+
+microphone:
   - platform: i2s_audio
-    type: audio_in
-    id: adf_i2s_in
+    adc_type: external
+    id: voice_assistant_mic
     i2s_audio_id: i2s_in
     i2s_din_pin: GPIO15
     pdm: false
@@ -140,24 +125,83 @@ adf_pipeline:
     sample_rate: 16000
     bits_per_sample: 32bit
 
-microphone:
-  - platform: adf_pipeline
-    id: adf_microphone
-    keep_pipeline_alive: true
-    pipeline:
-      - adf_i2s_in
-      - self
+# use speaker plattform for mix announcements and media player
+
+speaker:
+  - platform: i2s_audio
+    id: i2s_audio_speaker
+    i2s_audio_id: i2s_out
+    i2s_dout_pin: GPIO17
+    dac_type: external
+    channel: "mono"
+    i2s_mode: primary
+    buffer_duration: 100ms
+    timeout: never
+    sample_rate: 48000
+    bits_per_sample: 32bit
+
+  - platform: mixer
+    id: mixing_speaker
+    output_speaker: i2s_audio_speaker
+    num_channels: 2
+    source_speakers:
+      - id: announcement_mixing_input
+        timeout: never
+      - id: media_mixing_input
+        timeout: never
+
+  # Virtual speakers to resample each pipelines' audio, if necessary, as the mixer speaker requires the same sample rate
+  - platform: resampler
+    id: announcement_resampling_speaker
+    output_speaker: announcement_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+  - platform: resampler
+    id: media_resampling_speaker
+    output_speaker: media_mixing_input
+    sample_rate: 48000
+    bits_per_sample: 16
+
 
 media_player:
-  - platform: adf_pipeline
-    id: adf_media_player
-    name: "${friendly_name} Media Player"
-    keep_pipeline_alive: true
+  - platform: speaker
+    id: voice_assistant_media_player
+    name: "Media Player"
     internal: false
-    pipeline:
-      - self
-      - resampler
-      - adf_i2s_out
+    announcement_pipeline:
+      speaker: announcement_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 1  # Stereo audio is unnecessary for announcements
+      sample_rate: 48000
+    media_pipeline:
+      speaker: media_resampling_speaker
+      format: FLAC     # FLAC is the least processor intensive codec
+      num_channels: 2
+      sample_rate: 48000
+    on_announcement:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+    on_state:
+      if:
+        condition:
+          and:
+            - switch.is_off: timer_ringing
+            - not:
+                voice_assistant.is_running:
+            - not:
+                media_player.is_announcing:
+        then:
+          - mixer_speaker.apply_ducking:
+              id: media_mixing_input
+              decibel_reduction: 0
+              duration: 1.0s
+    files:
+    - id: timer_finished_sound
+      file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
+    - id: wake_word_triggered_sound
+      file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
 
 light:
   - platform: esp32_rmt_led_strip
@@ -166,7 +210,7 @@ light:
     rgb_order: GRB
     pin: GPIO42
     num_leds: 2
-    rmt_channel: 1
+    rmt_symbols: 96
     chipset: ws2812
     default_transition_length: 0s
     effects:
@@ -199,20 +243,65 @@ light:
 micro_wake_word:
   models:
     - model: ${wake_word}
+  microphone: voice_assistant_mic
   on_wake_word_detected:
-      - media_player.stop:
-      - light.turn_on:
-          id: rgb_front_led
-          blue: 0%
-          red: 0%
-          green: 100%
-          brightness: 75%
-          effect: "Slow Pulse"
-      - voice_assistant.start:
+    - if:
+        condition:
+          switch.is_on: use_wake_word
+        then:
+          - light.turn_on:
+              id: rgb_front_led
+              blue: 0%
+              red: 0%
+              green: 100%
+              brightness: 75%
+              effect: "Slow Pulse"
+          # If a timer is ringing: Stop it, do not start the voice assistant (We can stop timer from voice!)
+          - if:
+              condition:
+                switch.is_on: timer_ringing
+              then:
+                - switch.turn_off: timer_ringing
+                - micro_wake_word.start:
+              # Stop voice assistant if running
+              else:
+                - if:
+                    condition:
+                      switch.is_off: ducking_switch
+                    then:
+                      media_player.stop:
+                - if:
+                    condition:
+                      voice_assistant.is_running:
+                    then:
+                      voice_assistant.stop:
+                    # Stop any other media player announcement
+                    else:
+                      - if:
+                          condition:
+                            media_player.is_announcing:
+                          then:
+                            - media_player.stop:
+                                announcement: true
+                          # Start the voice assistant and play the wake sound, if enabled
+                          else:
+                            - if:
+                                condition:
+                                  switch.is_on: wake_sound
+                                then:
+                                  - script.execute:
+                                      id: play_sound
+                                      priority: true
+                                      sound_file: !lambda return id(wake_word_triggered_sound);
+                                  - delay: 300ms
+                            
+                            - voice_assistant.start:
+
 
 voice_assistant:
-  microphone: adf_microphone
-  media_player: adf_media_player
+  id: va
+  microphone: voice_assistant_mic
+  media_player: voice_assistant_media_player
   use_wake_word: false
   #vad_threshold: 3
   #noise_suppression_level: 1
@@ -256,14 +345,24 @@ voice_assistant:
         green: 100%
         brightness: 50%
         effect: "Slow Pulse"
+  on_start:
+    - mixer_speaker.apply_ducking:
+        id: media_mixing_input
+        decibel_reduction: 20  # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s         # The duration of the transition (default is no transition)
   on_end:
       then:
+        - wait_until:
+            not:
+              voice_assistant.is_running:
+        # Stop ducking audio.
+        - mixer_speaker.apply_ducking:
+            id: media_mixing_input
+            decibel_reduction: 0
+            duration: 1.0s
         - light.turn_off:
             id: rgb_front_led
         - voice_assistant.stop
-        - wait_until:
-            not:
-              media_player.is_playing:
         - script.execute: reset_led
         - if:
             condition:
@@ -291,6 +390,8 @@ voice_assistant:
         then:
           - micro_wake_word.start:
           - script.execute: reset_led
+  on_timer_finished:
+    - switch.turn_on: timer_ringing
 
 script:
   - id: reset_led
@@ -308,6 +409,53 @@ script:
                 effect: none
           else:
             - light.turn_off: rgb_front_led
+  # Script executed when we want to play sounds on the device.
+  - id: play_sound
+    parameters:
+      priority: bool
+      sound_file: "audio::AudioFile*"
+    then:
+      - lambda: |-
+          if (priority) {
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_STOP)
+              .set_announcement(true)
+              .perform();
+          }
+          if ( (id(voice_assistant_media_player).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
+            id(voice_assistant_media_player)
+              ->play_file(sound_file, true, false);
+          }
+  # Script executed when the timer is ringing, to playback sounds.
+  - id: enable_repeat_one
+    then:
+      # Turn on the repeat mode and pause for 500 ms between playlist items/repeats
+      - lambda: |-
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_ONE)
+              .set_announcement(true)
+              .perform();
+            id(voice_assistant_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 500);
+  - id: ring_timer
+    then:
+      - script.execute: enable_repeat_one
+      - script.execute:
+          id: play_sound
+          priority: true
+          sound_file: !lambda return id(timer_finished_sound);
+  - id: disable_repeat
+    then:
+      # Turn off the repeat mode and pause for 0 ms between playlist items/repeats
+      - lambda: |-
+            id(voice_assistant_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_OFF)
+              .set_announcement(true)
+              .perform();
+            id(voice_assistant_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 0);
+
 
 switch:
   - platform: gpio
@@ -352,10 +500,54 @@ switch:
             - lambda: id(voice_assistant_phase) = ${voice_assist_muted_phase_id};
       - script.execute: reset_led
 
+
   - platform: template
-    name: "${friendly_name} Pipeline"
-    id: pipeline_switch
+    name: "Enable ducking"
+    id: ducking_switch
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: mdi:volume-high
+
+  - platform: template
+    id: timer_ringing
+    optimistic: true
+    internal: true
+    restore_mode: ALWAYS_OFF
+    on_turn_on:
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+      - script.execute: ring_timer
+      - light.turn_on:
+          id: rgb_front_led
+          blue: 0%
+          red: 0%
+          green: 100%
+          brightness: 85%
+          effect: "Fast Pulse"
+      - delay: 15min
+      - switch.turn_off: timer_ringing
     on_turn_off:
-      - media_player.stop
+      - script.execute: disable_repeat
+      # Stop any current annoucement (ie: stop the timer ring mid playback)
+      - if:
+          condition:
+            media_player.is_announcing:
+          then:
+            media_player.stop:
+              announcement: true
+      - mixer_speaker.apply_ducking:
+          id: media_mixing_input
+          decibel_reduction: 0
+          duration: 1.0s
+      - script.execute: reset_led
+    
+
+  - platform: template
+    id: wake_sound
+    name: "${friendly_name} Wake Sound"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    icon: "mdi:bullhorn"
+

--- a/firmware/esphome/echo-solo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-solo-b-voice-assist.yaml
@@ -143,7 +143,7 @@ speaker:
   - platform: mixer
     id: mixing_speaker
     output_speaker: i2s_audio_speaker
-    num_channels: 2
+    num_channels: 1
     source_speakers:
       - id: announcement_mixing_input
         timeout: never
@@ -176,7 +176,7 @@ media_player:
     media_pipeline:
       speaker: media_resampling_speaker
       format: FLAC     # FLAC is the least processor intensive codec
-      num_channels: 2
+      num_channels: 1
       sample_rate: 48000
     on_announcement:
       - mixer_speaker.apply_ducking:

--- a/firmware/esphome/echo-solo-b-voice-assist.yaml
+++ b/firmware/esphome/echo-solo-b-voice-assist.yaml
@@ -55,7 +55,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: 4.4.6
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32_S3_BOX_BOARD: "y"
       CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM: "16"
@@ -70,7 +71,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/gnumpi/esphome_audio
-      ref: dev-next
+      ref: pull/79/head
     components: [ adf_pipeline, i2s_audio ]
     refresh: 0s
 


### PR DESCRIPTION
As all used components are now also available upstream in ESPHome, this pull request tries to remove the adf_pipeline and esphome_audio as external dependency in favor of native components. It's compatible with the latest esp-idf (>5). It does not implement version pinning.
The PR also ports some functions from home assistant voice pe configuration:
[https://github.com/esphome/home-assistant-voice-pe/blob/dev/home-assistant-voice.yaml](https://github.com/esphome/home-assistant-voice-pe/blob/dev/home-assistant-voice.yaml)
- Timer support 
- Uninterrupted media playback (ducking on announcements)
- wake sounds

Tested on my Esparagus Echo Duo Rev. B